### PR TITLE
chore: add "why rust?" section

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,132 @@
-# Code of Conduct
+# Contributor Covenant Code of Conduct
 
-This project adheres to the Rust Code of Conduct, which can be found [here](https://www.rust-lang.org/conduct.html).
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+hanlin.tang@databricks.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+## Linux Foundation Code of Conduct
+
+Your use is additionally subject to the [Linux Foundation Code of Conduct](https://lfprojects.org/policies/code-of-conduct/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ wish to make by creating a new issue before making the change.
 ## Reporting issues
 
 Before reporting an issue on the
-[issue tracker](https://github.com/abrassel/unitycatalog-rs/issues),
+[issue tracker](https://github.com/unitycatalog/unitycatalog-rs/issues),
 please check that it has not already been reported by searching for some related
 keywords.
 
@@ -19,7 +19,7 @@ Try to do one pull request per change.
 ### Updating the changelog
 
 Update the changes you have made in
-[CHANGELOG](https://github.com/abrassel/unitycatalog-rs/blob/main/CHANGELOG.md)
+[CHANGELOG](https://github.com/unitycatalog/unitycatalog-rs/blob/main/CHANGELOG.md)
 file under the **Unreleased** section.
 
 Add the changes of your pull request to one of the following subsections,
@@ -42,7 +42,7 @@ If the required subsection does not exist yet under **Unreleased**, create it!
 This is no different than other Rust projects.
 
 ```shell
-git clone https://github.com/abrassel/unitycatalog-rs
+git clone https://github.com/unitycatalog/unitycatalog-rs
 cd unitycatalog-rs
 cargo test
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # unitycatalog-rs
 
-[![CI](https://github.com/unitycatalog/unitycatalog-rs/workflows/CI/badge.svg)](https://github.com/unitycatalog/unitycatalog-rs/actions)
+[![CI](https://github.com/unitycatalog/unitycatalog-rs/workflows/CI/badge.svg)](https://github.com/unitycatalog/unitycatalog-rs/actions) ![crates.io](https://img.shields.io/crates/v/unitycatalog.svg?label=unitycatalog) ![crates.io](https://img.shields.io/crates/v/unitycatalog-client.svg?label=unitycatalog-client) ![crates.io](https://img.shields.io/crates/v/unitycatalog-sys.svg?label=unitycatalog-sys)
 
 unitycatalog-rs serves an alternate implementation of the [Unity Catalog protocol](https://github.com/unitycatalog/unitycatalog/tree/main/api). The Unity Catalog protocol is a specification for a multi-modal catalog for data and AI assets.
 
@@ -9,7 +9,8 @@ unitycatalog-rs serves an alternate implementation of the [Unity Catalog protoco
 Rust was chosen as a language for the second implementation for a few reasons:
 
 - **Performance**: Rust compiles to native bytecode, enabling it to be used in performance-critical and constrained environments.
-- **FFI**: As Rust uses the C ABI, bindings can be exposed to any language, like C, Go, Python, etc.
+- **FFI**: As Rust uses the C ABI, bindings can be exposed to any language, like C, Go, etc.
+- **Python & Rust**: Python and Rust are a strong pairing, especially in the AI ecosystem ([tokenizers](https://github.com/huggingface/tokenizers), [pydantic](https://github.com/pydantic/pydantic-core), etc).
 - **Ecosystem**: Rust has a rich ecosystem of libraries, especially related to big data processing ([delta-rs](https://github.com/delta-io/delta-rs), [datafusion](https://github.com/apache/datafusion), etc).
 - **Safety**: Rust's strong type system and ownership model make it difficult to write code that is unsafe or has undefined behavior. When dealing with data assets, especially when it comes to access control, this helps us ensure that we are not introducing security vulnerabilities.
 - **We want to write it!**: Most importantly, we like writing Rust!

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # unitycatalog-rs
 
-[![Crates.io](https://img.shields.io/crates/v/unitycatalog-rs.svg)](https://crates.io/crates/unitycatalog-rs)
-[![Docs.rs](https://docs.rs/unitycatalog-rs/badge.svg)](https://docs.rs/unitycatalog-rs)
-[![CI](https://github.com/abrassel/unitycatalog-rs/workflows/CI/badge.svg)](https://github.com/abrassel/unitycatalog-rs/actions)
-[![Rust GitHub Template](https://img.shields.io/badge/Rust%20GitHub-Template-blue)](https://rust-github.github.io/)
+[![CI](https://github.com/unitycatalog/unitycatalog-rs/workflows/CI/badge.svg)](https://github.com/unitycatalog/unitycatalog-rs/actions)
 
+unitycatalog-rs serves an alternate implementation of the [Unity Catalog protocol](https://github.com/unitycatalog/unitycatalog/tree/main/api). The Unity Catalog protocol is a specification for a multi-modal catalog for data and AI assets.
 
-## Installation
+## Why Rust?
 
-### Cargo
+Rust was chosen as a language for the second implementation for a few reasons:
 
-* Install the rust toolchain in order to have cargo installed by following
-  [this](https://www.rust-lang.org/tools/install) guide.
-* run `cargo install unitycatalog-rs`
+- **Performance**: Rust compiles to native bytecode, enabling it to be used in performance-critical and constrained environments.
+- **FFI**: As Rust uses the C ABI, bindings can be exposed to any language, like C, Go, Python, etc.
+- **Ecosystem**: Rust has a rich ecosystem of libraries, especially related to big data processing ([delta-rs](https://github.com/delta-io/delta-rs), [datafusion](https://github.com/apache/datafusion), etc).
+- **Safety**: Rust's strong type system and ownership model make it difficult to write code that is unsafe or has undefined behavior. When dealing with data assets, especially when it comes to access control, this helps us ensure that we are not introducing security vulnerabilities.
+- **We want to write it!**: Most importantly, we like writing Rust!
 
 ## License
 

--- a/models/README.md
+++ b/models/README.md
@@ -1,4 +1,6 @@
-# Rust=generated structs for Unity Catalog
+# Rust-generated structs for Unity Catalog
+
+![crates.io](https://img.shields.io/crates/v/unitycatalog-sys.svg)
 
 ## Overview
 


### PR DESCRIPTION
Adds a "why rust?" section based on thoughts in the slack. Closes #4.

Also updates the Code of Conduct from the main Java repo (thank you @dennyglee!)
